### PR TITLE
Prepare 0.2.1 Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "ssss"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/sss.git"
-version = "0.2.0"
+version = "0.2.1"
 rust-version = "1.65.0"
 
 [package.metadata.cargo-all-features]


### PR DESCRIPTION
* Update to `0.2.1` to account for dependency updates to clear out RUSTSEC warnings.